### PR TITLE
Add support for DNS caching in network namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ namespaced-openvpn
     sudo ip netns exec protected sudo -u $USER -i
 
 The main implementation idea of `namespaced-openvpn` is this: instead of connecting a network namespace to the physical network using virtual Ethernet adapters and bridging, it suffices to transfer a tunnel interface into the namespace, while the process managing the tunnel (in this case `openvpn`) remains in the root namespace.
+Furthermore, if `dnsmasq` is installed it's configured as a caching-only DNS server in the network namespace.
 
 ## Summary
 

--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -29,6 +29,7 @@ LOG = logging.getLogger()
 
 DEFAULT_NAMESPACE = "protected"
 
+DNSMASQ_CMD = '/usr/sbin/dnsmasq'
 OPENVPN_CMD = '/usr/sbin/openvpn'
 IP_CMD = '/sbin/ip'
 SYSCTL_CMD = '/sbin/sysctl'
@@ -68,7 +69,14 @@ def setup_namespace(namespace):
 def parse_dhcp_opts(env):
     """Parse DNS servers pushed by the server as DHCP options from the env."""
     dnsopt_to_values = defaultdict(list)
-    i = 1
+
+    if os.path.exists(DNSMASQ_CMD):
+        # add local dnsmasq IP address
+        dnsopt_to_values['DNS'].append('127.0.0.1')
+        i = 2
+    else:
+        i = 1
+
     while True:
         foreign_opt = env.get('foreign_option_%d' % (i,))
         if not foreign_opt:
@@ -177,6 +185,14 @@ def route_up(args):
         # XXX i can't figure out how to reimplement openvpn's command lexer,
         # just toss the command into /bin/sh's maw
         subprocess.check_call(routeup_cmd, shell=True)
+
+    if os.path.exists(DNSMASQ_CMD):
+        # set up dnsmasq local dns cache
+        subprocess.check_call([
+            IP_CMD, 'netns', 'exec', namespace,
+            DNSMASQ_CMD, '--bind-interfaces', '--listen-address=127.0.1.1', '--cache-size=500',
+            '--proxy-dnssec', '--pid-file=/var/run/netns/dnsmasq.pid',
+        ])
 
     return 0
 


### PR DESCRIPTION
Add support for dns-caching in network namespace:
- use `dnsmasq` if it's available
  - no need for command line switches for this, set it up automatically if it's installed
- add `nameserver 127.0.0.1` as the first entry in `resolv.conf` of network namespace
- run `dnsmasq` in network namespace if everything is set up with the following arguments:
```sh
ip netns exec protected /usr/sbin/dnsmasq --bind-interfaces --listen-address=127.0.1.1 --cache-size=500 --proxy-dnssec --pid-file=/var/run/netns/dnsmasq.pid
```

**Notes:**
- I couldn't try the script itself out yet (only manually applied the above changes), but you get the idea what  it's all about :)

**PS:**
I'd like to thank You for this repo and your detailed write up about the possible issues.
I have spent the last couple of weeks to read and experiment about these. I came across lot of possible solutions (old user based + `ipfilter` solution, `chgroups` + `ipfilter`, namespace + `ipfilter`, etc.), but none of them was so clean and straightforward as yours.
Thank You!