### PR TITLE
Fix shellcheck errors

### DIFF
--- a/seal-unseal-gateway
+++ b/seal-unseal-gateway
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+# to appease ShellCheck SC2154, these are exported by openvpn
+declare script_type trusted_ip
+
 # add the rules on up or route-up, otherwise delete them
-if [[ "$script_type" == "up" ]] || [[ "$script_type" == "route-up" ]]; then
+if [ "$script_type" = "up" ] || [ "$script_type" = "route-up" ]; then
 	ACTION="-A"
 else
 	ACTION="-D"
 fi
 
-if [[ -n "$trusted_ip" ]]; then
+if [ -n "$trusted_ip" ]; then
 	# trusted_ip is the publicly routable IP of the remote
 	# let openvpn's user (typically either root or a dedicated user) talk to it:
-	/sbin/iptables $ACTION OUTPUT -d $trusted_ip -m owner --uid-owner $EUID -j ACCEPT
+	/sbin/iptables $ACTION OUTPUT -d "$trusted_ip" -m owner --uid-owner $EUID -j ACCEPT
 	# forbid everyone else from doing so:
-	/sbin/iptables $ACTION OUTPUT -d $trusted_ip -j REJECT
+	/sbin/iptables $ACTION OUTPUT -d "$trusted_ip" -j REJECT
 	RESULT=0
 else
 	echo "trusted_ip not set; rules may have to be cleaned up manually"


### PR DESCRIPTION
This fixes all errors reported by ShellCheck. I also switched from [[ to the [ syntax, which is not required by ShellCheck but is more standard.