### PR TITLE
Support IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,5 +154,4 @@ Bugs:
 
 Wishlist:
 
-* Support for tunnelling IPv6 (when the remote VPN provider offers it).
 * Ideally, there would be an option to offer both limited protection to the root namespace (e.g., without protecting against route injection) and full protection to an isolated namespace. This seems difficult to achieve in a nondisruptive way.

--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -84,6 +84,7 @@ def parse_dhcp_opts(env):
         if not foreign_opt:
             break
         # e.g., foreign_option_1=dhcp-option DNS 8.8.8.8
+        # or    foreign_option_1=dhcp-option DNS6 2001:4860:4860::8888
         if foreign_opt.startswith('dhcp-option'):
             opt_pieces = foreign_opt.split()
             if len(opt_pieces) == 3:
@@ -98,7 +99,8 @@ def write_resolvconf(outfile, opts):
     MAX_SEARCH_DOMAINS = 6
     MAX_SEARCH_LEN = 256
 
-    nameservers = opts['DNS'][:MAX_NAMESERVERS]
+    # Treat IPv6 nameservers the same as IPv4 nameservers
+    nameservers = (opts['DNS'] + opts['DNS6'])[:MAX_NAMESERVERS]
     if len(opts['DOMAIN']) == 1:
         domain = opts['DOMAIN'][0]
         search = opts['DOMAIN-SEARCH'][:MAX_SEARCH_DOMAINS]
@@ -157,40 +159,71 @@ def setup_dns(namespace, dns_type):
             subprocess.check_call([UMOUNT_CMD, mountdir])
             os.rmdir(mountdir)
 
+def assert_all_or_none(message, *variables):
+    if any(variables) and not all(variables):
+        raise ValueError(message, *variables)
+    return any(variables)
 
 def route_up(args):
     """Active ingredient: set up routing and DNS in the new namespace."""
     namespace, dns_type, preexisting_routeup = args
 
     dev = os.getenv('dev')
-    # this is the local IP assigned to the tun adapter
+
+    if not dev:
+        raise ValueError("Missing dev environment variable")
+
+    # this is the local IPv4 assigned to the tun adapter
     ifconfig_local = os.getenv('ifconfig_local')
     # this is the default gateway for the tun adapter (typically private IP space)
     route_vpn_gateway = os.getenv('route_vpn_gateway')
-    if not all((dev, ifconfig_local, route_vpn_gateway)):
-        raise ValueError(
-            "Bad options pushed from server",
-            dev, ifconfig_local, route_vpn_gateway
-        )
-    peer_addr = '%s/32' % (route_vpn_gateway,)
 
-    # transfer the tunnel interface and set it to UP
+    ifconfig_ipv6_local = os.getenv('ifconfig_ipv6_local')
+    ifconfig_ipv6_remote = os.getenv('ifconfig_ipv6_remote')
+    ifconfig_ipv6_netbits = os.getenv('ifconfig_ipv6_netbits')
+
+    have_ipv4 = assert_all_or_none(
+        "Bad ipv4 options pushed from server", ifconfig_local, route_vpn_gateway
+    )
+    have_ipv6 = assert_all_or_none(
+        "Bad ipv6 options pushed from server",
+        ifconfig_ipv6_local, ifconfig_ipv6_remote, ifconfig_ipv6_netbits
+    )
+
+    if not have_ipv4 and not have_ipv6:
+        raise ValueError("Got neither ipv4 nor ipv6 configuration from server")
+
     target = namespace if namespace != '' else '1'
     subprocess.check_call([IP_CMD, 'link', 'set', dev, 'netns', target])
     subprocess.check_call(
         _enter_namespace_cmd(namespace) +
         [IP_CMD, 'link', 'set', dev, 'up']
     )
-    # give it its address
-    subprocess.check_call(
-        _enter_namespace_cmd(namespace) +
-        [IP_CMD, 'addr', 'add', ifconfig_local, 'peer', peer_addr, 'dev', dev]
-    )
-    # route all traffic over the tunnel
-    subprocess.check_call(
-        _enter_namespace_cmd(namespace) +
-        [IP_CMD, 'route', 'add', 'default', 'via', route_vpn_gateway, 'src', ifconfig_local]
-    )
+
+    if have_ipv4:
+        peer_addr = '%s/32' % (route_vpn_gateway,)
+        # transfer the tunnel interface and set it to UP
+        # give it its ipv4 address
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IP_CMD, 'addr', 'add', ifconfig_local, 'peer', peer_addr, 'dev', dev]
+        )
+        # route all traffic over the tunnel
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IP_CMD, 'route', 'add', 'default', 'via', route_vpn_gateway, 'src', ifconfig_local]
+        )
+
+    if have_ipv6:
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IP_CMD, 'addr', 'add', ifconfig_ipv6_local, 'peer',
+            ('%s/%s' % (ifconfig_ipv6_remote, ifconfig_ipv6_netbits)), 'dev', dev]
+        )
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IP_CMD, '-6', 'route', 'add', 'default', 'dev', dev]
+        )
 
     setup_dns(namespace, dns_type)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,11 +26,13 @@ class TestDHCPOpts(unittest.TestCase):
             'foreign_option_2': 'dhcp-option DNS 8.8.4.4',
             'foreign_option_3': 'dhcp-option DISABLE-NBT',
             'foreign_option_4': 'dhcp-option DOMAIN example.com',
+            'foreign_option_5': 'dhcp-option DNS6 2001:4860:4860::8888',
         }
         self.assertEqual(
             parse_dhcp_opts(env),
             {
                 'DNS': ['8.8.8.8', '8.8.4.4'],
+                'DNS6': ['2001:4860:4860::8888'],
                 'DOMAIN': ['example.com'],
             }
         )
@@ -41,11 +43,12 @@ class TestWriteResolvConf(unittest.TestCase):
     def test_dns_only(self):
         opts = defaultdict(list)
         opts['DNS'] = ['10.0.0.1', '10.0.0.2']
+        opts['DNS6'] = ['2001:4860:4860::8888']
         outfile = StringIO()
         write_resolvconf(outfile, opts)
         self.assertEqual(
             outfile.getvalue(),
-            'nameserver 10.0.0.1\nnameserver 10.0.0.2\n'
+            'nameserver 10.0.0.1\nnameserver 10.0.0.2\nnameserver 2001:4860:4860::8888\n'
         )
 
     def test_domain(self):


### PR DESCRIPTION
I am not sure if source code formatting is correct.

I was not able to execute the test but I hope it is correct. The code itself works with my vpn ipv4+ipv6 provider.

```
$ python3 tests/tests.py
Traceback (most recent call last):
  File "tests/tests.py", line 15, in <module>
    from .namespaced_openvpn import parse_dhcp_opts
ModuleNotFoundError: No module named '__main__.namespaced_openvpn'; '__main__' is not a package
```

My vpn provider pushes multiple routes for ipv6 like so (as seen from openvpn output)

```
add_route_ipv6(::/3 -> fde6:7a:7d20:dae::1 metric -1) dev tun0
/usr/bin/ip -6 route add ::/3 dev tun0
add_route_ipv6(2000::/4 -> fde6:7a:7d20:dae::1 metric -1) dev tun0
/usr/bin/ip -6 route add 2000::/4 dev tun0
add_route_ipv6(3000::/4 -> fde6:7a:7d20:dae::1 metric -1) dev tun0
/usr/bin/ip -6 route add 3000::/4 dev tun0
add_route_ipv6(fc00::/7 -> fde6:7a:7d20:dae::1 metric -1) dev tun0
/usr/bin/ip -6 route add fc00::/7 dev tun0
```

(as seen by the script in form of environment variables)
```
route_ipv6_gateway_4=fde6:7a:7d20:1b0e::1
route_ipv6_network_4=fc00::/7
route_ipv6_gateway_3=fde6:7a:7d20:1b0e::1
route_ipv6_network_3=3000::/4
route_ipv6_gateway_2=fde6:7a:7d20:1b0e::1
route_ipv6_network_2=2000::/4
route_ipv6_gateway_1=fde6:7a:7d20:1b0e::1
route_ipv6_network_1=::/3
```

Instead of applying them like this I decided to do the most simple thing and add only one route for all IPv6 traffic (the same way it is done for IPv4). I believe this is fine when the intention is to use the tun interface as the only interface where we do not need to worry about routing local network traffic correctly. I did not use the `via` or `src` options which the IPv4 code does because they did not seem necessary but I am not sure what is more correct.