### PR TITLE
desupport Python 2, switch to #!/usr/bin/python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 .PHONY: test install
 
 test:
-	python2 -m flake8 ./namespaced-openvpn tests/
 	python3 -m flake8 ./namespaced-openvpn tests/
-	python2 -m unittest discover
 	python3 -m unittest discover
 
 install:

--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 """
 Wrap openvpn to run across two network namespaces:
@@ -9,9 +9,6 @@ Wrap openvpn to run across two network namespaces:
        is secure against deanonymization attacks like DHCP route injection,
        "port fail", and ValdikSS's asymmetric routing trick.
 """
-
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import argparse
 import base64
@@ -24,7 +21,7 @@ import sys
 import tempfile
 from collections import defaultdict
 
-VERSION = '0.4.0'
+VERSION = '0.5.0'
 
 LOG = logging.getLogger()
 
@@ -359,10 +356,8 @@ def parse_validate_args(cl_args):
         with open(config_args.config) as config_file_obj:
             preexisting_routeup = routeup_from_config(config_file_obj)
     if preexisting_routeup:
-        preexisting_routeup = base64.b64encode(preexisting_routeup.encode('utf-8'))
-        # XXX make this the native string type, to match `namespace` and `dns`
-        if sys.version_info[0] == 3:
-            preexisting_routeup = preexisting_routeup.decode('ascii')
+        # make this the native string type, to match `namespace` and `dns`
+        preexisting_routeup = base64.b64encode(preexisting_routeup.encode('utf-8')).decode('ascii')
     else:
         preexisting_routeup = B64_EMPTY_SENTINEL
     return args, openvpn_args, preexisting_routeup


### PR DESCRIPTION
Distributions are increasingly shipping without a /usr/bin/python at all.
Anyone who has permissions to use namespaced-openvpn presumably also
has permissions to install python3.