### PR TITLE
Fix issue with --route-up hook when script is not in $PATH

### DIFF
--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -386,9 +386,10 @@ def main():
     # pass our own path as the route-up, with some extra data
     namespace = args.namespace if args.namespace != "" else '""'
     disable_arg = serialize_disableargs(args.disable_ipv4, args.disable_ipv6)
+    script_name = os.path.abspath(__file__)
     execv_args += [
         '--route-up',
-        '%s %s %s %s %s' % (__file__, namespace, args.dns, preexisting_routeup, disable_arg)
+        '%s %s %s %s %s' % (script_name, namespace, args.dns, preexisting_routeup, disable_arg)
     ]
 
     os.execv(OPENVPN_CMD, execv_args)


### PR DESCRIPTION
When using the `--daemon` option, the script doesn't work, unless it is in $PATH.

Log looks like:

> [...]
> Fri Aug 21 16:14:19 2020 TUN/TAP device tun1 opened
> Fri Aug 21 16:14:19 2020 WARNING: Failed running command (--route-up): could not execute external program
> Fri Aug 21 16:14:19 2020 Initialization Sequence Completed

As putting the script in $PATH is not always desirable, a general solution is to use the full path of the script for `--route-up`.