### PR TITLE
Firewall DNS

### DIFF
--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -30,6 +30,7 @@ DEFAULT_NAMESPACE = "protected"
 OPENVPN_CMD = '/usr/sbin/openvpn'
 IP_CMD = '/sbin/ip'
 IPTABLES_CMD = '/sbin/iptables'
+IP6TABLES_CMD = '/sbin/ip6tables'
 NSENTER_CMD = '/usr/bin/nsenter'
 MOUNT_CMD = '/bin/mount'
 UMOUNT_CMD = '/bin/umount'
@@ -154,18 +155,34 @@ def setup_dns(namespace, dns_type):
         with open(etc_resolvconf, 'w') as outfile:
             write_resolvconf(outfile, resolv_data)
 
+        # Insert/Prepend rules instead of appending because we can't delete the rules.
+        # Prepending allows the rules to still work if on second run, the DNS address changes.
+
+        # Block all other DNS (port 53 UDP) traffic
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IPTABLES_CMD, '-I', 'OUTPUT', '1', '-p', 'udp', '--dport', '53', '-j', 'DROP']
+        )
+
         # Allow the specified DNS addresses
         for dns in resolv_data['DNS']:
             subprocess.check_call(
                 _enter_namespace_cmd(namespace) +
-                [IPTABLES_CMD, '-A', 'OUTPUT', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT', '-d', dns]
+                [IPTABLES_CMD, '-I', 'OUTPUT', '1', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT', '-d', dns]
             )
 
         # Block all other DNS (port 53 UDP) traffic
         subprocess.check_call(
             _enter_namespace_cmd(namespace) +
-            [IPTABLES_CMD, '-A', 'OUTPUT', '-p', 'udp', '--dport', '53', '-j', 'DROP']
+            [IP6TABLES_CMD, '-I', 'OUTPUT', '1', '-p', 'udp', '--dport', '53', '-j', 'DROP']
         )
+
+        # Repeat for DNS6
+        for dns in resolv_data['DNS6']:
+            subprocess.check_call(
+                _enter_namespace_cmd(namespace) +
+                [IP6TABLES_CMD, '-I', 'OUTPUT', '1', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT', '-d', dns]
+            )
 
     finally:
         if mountdir is not None:

--- a/namespaced-openvpn
+++ b/namespaced-openvpn
@@ -29,6 +29,7 @@ DEFAULT_NAMESPACE = "protected"
 
 OPENVPN_CMD = '/usr/sbin/openvpn'
 IP_CMD = '/sbin/ip'
+IPTABLES_CMD = '/sbin/iptables'
 NSENTER_CMD = '/usr/bin/nsenter'
 MOUNT_CMD = '/bin/mount'
 UMOUNT_CMD = '/bin/umount'
@@ -152,6 +153,20 @@ def setup_dns(namespace, dns_type):
     try:
         with open(etc_resolvconf, 'w') as outfile:
             write_resolvconf(outfile, resolv_data)
+
+        # Allow the specified DNS addresses
+        for dns in resolv_data['DNS']:
+            subprocess.check_call(
+                _enter_namespace_cmd(namespace) +
+                [IPTABLES_CMD, '-A', 'OUTPUT', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT', '-d', dns]
+            )
+
+        # Block all other DNS (port 53 UDP) traffic
+        subprocess.check_call(
+            _enter_namespace_cmd(namespace) +
+            [IPTABLES_CMD, '-A', 'OUTPUT', '-p', 'udp', '--dport', '53', '-j', 'DROP']
+        )
+
     finally:
         if mountdir is not None:
             subprocess.check_call([UMOUNT_CMD, mountdir])


### PR DESCRIPTION
Automatically adds firewall rules to block any DNS requests (UDP packets on port 53) that does not go to one of the DNS addresses specified/pushed by the VPN server.

This solves the problem of *"the bind mount will silently disappear in the protected namespace"*, by blocking DNS requests that don't go to the servers we want.

Downsides: 
- Blocks all UDP traffic on port 53. So if someone for some reason need port 53 UDP, it won't work.
- If you end a connection, and the namespace is still up, and run namespaced-openvpn again, it will increase the iptables chain by 2. This is obviously reset upon restart or removing the protected namespace. This is not really a limitation, just lazy coding :D.

Note:
I only tested this on IPv4 connections, I don't know if IPv6 connections will work (it should, just not tested).